### PR TITLE
[Fix] Fix news image link to newsDetail

### DIFF
--- a/src/resources/views/pages/tin-tuc.hbs
+++ b/src/resources/views/pages/tin-tuc.hbs
@@ -5,7 +5,7 @@
       {{#each news}}
         <div class='card'>
           <div class='image-container'>
-            <a href='/tin-tuc'>
+            <a href='/tin-tuc/{{convertToSlug title}}'>
               <img class='card-img' src='{{image}}' alt='{{title}}' />
             </a>
           </div>


### PR DESCRIPTION
## Tên:
TriPu

## PR này để làm gì:
Đổi lại link của image chỉ tới newsDetail page tương ứng

## Danh sách màn ảnh hưởng:
News